### PR TITLE
db : initial db tables

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -5,6 +5,6 @@ export default {
     out: "./sqlite/migrations",
     dialect: "sqlite",
     dbCredentials: {
-        url: Bun.env.DB || "sqlite/realworld.sqlite",
+        url: Bun.env.DB || "sqlite/elestrals_api.sqlite,
     },
 } satisfies Config;

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -5,6 +5,6 @@ export default {
     out: "./sqlite/migrations",
     dialect: "sqlite",
     dbCredentials: {
-        url: Bun.env.DB || "sqlite/elestrals_api.sqlite,
+        url: Bun.env.DB || "sqlite/elestrals_api.sqlite",
     },
 } satisfies Config;

--- a/sqlite/migrations/0000_conscious_dagger.sql
+++ b/sqlite/migrations/0000_conscious_dagger.sql
@@ -1,0 +1,91 @@
+CREATE TABLE `canvas` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text
+);
+--> statement-breakpoint
+CREATE TABLE `cards` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text,
+	`base_name` text,
+	`title` text,
+	`alias` text,
+	`set_number` text,
+	`card_type` text,
+	`rarity` text,
+	`canvas` integer,
+	`frame_material` integer,
+	`artist` text,
+	`set_id` text,
+	`render` text,
+	`attack` integer,
+	`defense` integer,
+	`serialized_stellar` integer,
+	`serialized_population` integer,
+	`is_origin` integer,
+	`prize_rank` integer,
+	`printed_effect` text,
+	`effect_id` text,
+	`subclass_1` integer,
+	`subclass_2` integer,
+	`cost_display` text,
+	`total_cost` integer,
+	`fire_cost` integer,
+	`earth_cost` integer,
+	`thunder_cost` integer,
+	`water_cost` integer,
+	`wind_cost` integer,
+	`frost_cost` integer,
+	`lunar_cost` integer,
+	`solar_cost` integer,
+	`omni_cost` integer,
+	FOREIGN KEY (`canvas`) REFERENCES `canvas`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`frame_material`) REFERENCES `frames`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`set_id`) REFERENCES `sets`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`subclass_1`) REFERENCES `subclasses`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`subclass_2`) REFERENCES `subclasses`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `effects` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`effect` text
+);
+--> statement-breakpoint
+CREATE TABLE `frames` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text
+);
+--> statement-breakpoint
+CREATE TABLE `series` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text,
+	`image` text,
+	`icon` text
+);
+--> statement-breakpoint
+CREATE TABLE `sets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text,
+	`abbr` text,
+	`series_id` text,
+	`series_code` text,
+	`release_date` datetime,
+	`image` text,
+	`icon` text,
+	`stamp` text,
+	`logo` text,
+	FOREIGN KEY (`series_id`) REFERENCES `series`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `subclasses` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text
+);
+--> statement-breakpoint
+CREATE TABLE `variants` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`variant` text,
+	`card_id` text,
+	`image` text,
+	`is_primary` integer,
+	FOREIGN KEY (`card_id`) REFERENCES `cards`(`id`) ON UPDATE no action ON DELETE no action
+);

--- a/sqlite/migrations/meta/0000_snapshot.json
+++ b/sqlite/migrations/meta/0000_snapshot.json
@@ -1,0 +1,619 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ff4b0a8c-d472-4bc0-be3d-aeec23cb78e6",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "canvas": {
+      "name": "canvas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cards": {
+      "name": "cards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_name": {
+          "name": "base_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "set_number": {
+          "name": "set_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "card_type": {
+          "name": "card_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canvas": {
+          "name": "canvas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frame_material": {
+          "name": "frame_material",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "render": {
+          "name": "render",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attack": {
+          "name": "attack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defense": {
+          "name": "defense",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serialized_stellar": {
+          "name": "serialized_stellar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serialized_population": {
+          "name": "serialized_population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_origin": {
+          "name": "is_origin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_rank": {
+          "name": "prize_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "printed_effect": {
+          "name": "printed_effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effect_id": {
+          "name": "effect_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subclass_1": {
+          "name": "subclass_1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subclass_2": {
+          "name": "subclass_2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_display": {
+          "name": "cost_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_cost": {
+          "name": "fire_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "earth_cost": {
+          "name": "earth_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thunder_cost": {
+          "name": "thunder_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "water_cost": {
+          "name": "water_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wind_cost": {
+          "name": "wind_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frost_cost": {
+          "name": "frost_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lunar_cost": {
+          "name": "lunar_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "solar_cost": {
+          "name": "solar_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "omni_cost": {
+          "name": "omni_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cards_canvas_canvas_id_fk": {
+          "name": "cards_canvas_canvas_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "canvas",
+          "columnsFrom": [
+            "canvas"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cards_frame_material_frames_id_fk": {
+          "name": "cards_frame_material_frames_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "frames",
+          "columnsFrom": [
+            "frame_material"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cards_set_id_sets_id_fk": {
+          "name": "cards_set_id_sets_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "sets",
+          "columnsFrom": [
+            "set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cards_subclass_1_subclasses_id_fk": {
+          "name": "cards_subclass_1_subclasses_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "subclasses",
+          "columnsFrom": [
+            "subclass_1"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cards_subclass_2_subclasses_id_fk": {
+          "name": "cards_subclass_2_subclasses_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "subclasses",
+          "columnsFrom": [
+            "subclass_2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "effects": {
+      "name": "effects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "frames": {
+      "name": "frames",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sets": {
+      "name": "sets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abbr": {
+          "name": "abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_code": {
+          "name": "series_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stamp": {
+          "name": "stamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sets_series_id_series_id_fk": {
+          "name": "sets_series_id_series_id_fk",
+          "tableFrom": "sets",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subclasses": {
+      "name": "subclasses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "variants": {
+      "name": "variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "variants_card_id_cards_id_fk": {
+          "name": "variants_card_id_cards_id_fk",
+          "tableFrom": "variants",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/sqlite/migrations/meta/_journal.json
+++ b/sqlite/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1749911374723,
+      "tag": "0000_conscious_dagger",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,0 +1,16 @@
+import { Database, constants } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import config from "../../drizzle.config";
+
+import * as schema from "./schema";
+
+const sqlite = new Database(config.dbCredentials.url, { create: true });
+sqlite.exec("PRAGMA journal_mode = WAL;");
+sqlite.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
+
+export const db = drizzle(sqlite, { schema });
+export const closeDb = () => sqlite.close();
+export const rawDb = sqlite;
+
+export default db;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -28,13 +28,13 @@ export const sets = sqliteTable("sets", {
   image: text("image"),
   icon: text("icon"),
   stamp: text("stamp"),
-  logo: text("logo")
+  logo: text("logo"),
 });
 
 export const setsRelations = relations(sets, ({ one }) => ({
   series: one(series, {
     fields: [sets.series_id],
-    references: [series.id]
+    references: [series.id],
   })
 }));
 
@@ -42,8 +42,18 @@ export const series = sqliteTable("series", {
   id: text("id").primaryKey().notNull(),
   name: text("name"),
   image: text("image"),
-  icon: text("icon")
+  icon: text("icon"),
 });
+
+export const CardTypes = ["elestral", "spirit", "rune_divine", "rune_staduim", "rune_artifact", "rune_counter", "rune_invoke"] as const;
+Object.freeze(CardTypes);
+
+export type CardType = (typeof CardTypes)[number];
+
+export const CardRarities = ["rare", "stellar_rare", "common", "uncommon"] as const;
+Object.freeze(CardTypes);
+
+export type CardRarity = (typeof CardRarities)[number];
 
 export const cards = sqliteTable("cards", {
   id: text("id").primaryKey().notNull(),
@@ -53,10 +63,10 @@ export const cards = sqliteTable("cards", {
   alias: text("alias"),
   set_number: text("set_number"),
   card_type: text("card_type", { 
-    enum: ["elestral", "spirit", "rune_divine", "rune_staduim", "rune_artifact", "rune_counter", "rune_invoke"] 
+    enum: CardTypes
   }),
   rarity: text("rarity", { 
-    enum: ["rare", "stellar_rare", "common", "uncommon"] 
+    enum: CardRarities
   }),
   canvas: integer("canvas").references(() => canvas.id),
   frame_material: integer("frame_material").references(() => frames.id),
@@ -84,7 +94,7 @@ export const cards = sqliteTable("cards", {
   frost_cost: integer("frost_cost"),
   lunar_cost: integer("lunar_cost"),
   solar_cost: integer("solar_cost"),
-  omni_cost: integer("omni_cost")
+  omni_cost: integer("omni_cost"),
 });
 
 export const cardsRelations = relations(cards, ({ one }) => ({
@@ -107,7 +117,7 @@ export const cardsRelations = relations(cards, ({ one }) => ({
   subclass2: one(subclasses, {
     fields: [cards.subclass_2],
     references: [subclasses.id]
-  })
+  }),
 }));
 
 export const variants = sqliteTable("variants", {
@@ -115,7 +125,7 @@ export const variants = sqliteTable("variants", {
   variant: text("variant"),
   card_id: text("card_id").references(() => cards.id),
   image: text("image"),
-  is_primary: integer("is_primary")
+  is_primary: integer("is_primary"),
 });
 
 export const variantsRelations = relations(variants, ({ one }) => ({
@@ -127,20 +137,20 @@ export const variantsRelations = relations(variants, ({ one }) => ({
 
 export const canvas = sqliteTable("canvas", {
   id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
-  name: text("name")
+  name: text("name"),
 });
 
 export const frames = sqliteTable("frames", {
   id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
-  name: text("name")
+  name: text("name"),
 });
 
 export const subclasses = sqliteTable("subclasses", {
   id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
-  name: text("name")
+  name: text("name"),
 });
 
 export const effects = sqliteTable("effects", {
   id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
-  effect: text("effect")
+  effect: text("effect"),
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,146 @@
+import { relations } from "drizzle-orm";
+import {
+  customType,
+  integer,
+  sqliteTable,
+  text,
+} from "drizzle-orm/sqlite-core";
+
+const timestamp = customType<{
+  data: Date;
+  driverData: string;
+}>({
+  dataType() {
+    return "datetime";
+  },
+  fromDriver(value: string): Date {
+    return new Date(value);
+  },
+});
+
+export const sets = sqliteTable("sets", {
+  id: text("id").primaryKey().notNull(),
+  name: text("name"),
+  abbr: text("abbr"),
+  series_id: text("series_id").references(() => series.id),
+  series_code: text("series_code"),
+  release_date: timestamp("release_date"),
+  image: text("image"),
+  icon: text("icon"),
+  stamp: text("stamp"),
+  logo: text("logo")
+});
+
+export const setsRelations = relations(sets, ({ one }) => ({
+  series: one(series, {
+    fields: [sets.series_id],
+    references: [series.id]
+  })
+}));
+
+export const series = sqliteTable("series", {
+  id: text("id").primaryKey().notNull(),
+  name: text("name"),
+  image: text("image"),
+  icon: text("icon")
+});
+
+export const cards = sqliteTable("cards", {
+  id: text("id").primaryKey().notNull(),
+  name: text("name"),
+  base_name: text("base_name"),
+  title: text("title"),
+  alias: text("alias"),
+  set_number: text("set_number"),
+  card_type: text("card_type", { 
+    enum: ["elestral", "spirit", "rune_divine", "rune_staduim", "rune_artifact", "rune_counter", "rune_invoke"] 
+  }),
+  rarity: text("rarity", { 
+    enum: ["rare", "stellar_rare", "common", "uncommon"] 
+  }),
+  canvas: integer("canvas").references(() => canvas.id),
+  frame_material: integer("frame_material").references(() => frames.id),
+  artist: text("artist"),
+  set_id: text("set_id").references(() => sets.id),
+  render: text("render"),
+  attack: integer("attack"),
+  defense: integer("defense"),
+  serialized_stellar: integer("serialized_stellar"),
+  serialized_population: integer("serialized_population"),
+  is_prize_card: integer("is_prize_card"),
+  prize_rank: integer("prize_rank"),
+  printed_effect: text("printed_effect"),
+  effect_id: text("effect_id"),
+  is_prize_card: integer("is_origin"),
+  subclass_1: integer("subclass_1").references(() => subclasses.id),
+  subclass_2: integer("subclass_2").references(() => subclasses.id),
+  cost_display: text("cost_display"),
+  total_cost: integer("total_cost"),
+  fire_cost: integer("fire_cost"),
+  earth_cost: integer("earth_cost"),
+  thunder_cost: integer("thunder_cost"),
+  water_cost: integer("water_cost"),
+  wind_cost: integer("wind_cost"),
+  frost_cost: integer("frost_cost"),
+  lunar_cost: integer("lunar_cost"),
+  solar_cost: integer("solar_cost"),
+  omni_cost: integer("omni_cost")
+});
+
+export const cardsRelations = relations(cards, ({ one }) => ({
+  canvas: one(canvas, {
+    fields: [cards.canvas],
+    references: [canvas.id]
+  }),
+  frameMaterial: one(frames, {
+    fields: [cards.frame_material],
+    references: [frames.id]
+  }),
+  set: one(sets, {
+    fields: [cards.set_id],
+    references: [sets.id]
+  }),
+  subclass1: one(subclasses, {
+    fields: [cards.subclass_1],
+    references: [subclasses.id]
+  }),
+  subclass2: one(subclasses, {
+    fields: [cards.subclass_2],
+    references: [subclasses.id]
+  })
+}));
+
+export const variants = sqliteTable("variants", {
+  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+  variant: text("variant"),
+  card_id: text("card_id").references(() => cards.id),
+  image: text("image"),
+  is_primary: integer("is_primary")
+});
+
+export const variantsRelations = relations(variants, ({ one }) => ({
+  card: one(cards, {
+    fields: [variants.card_id],
+    references: [cards.id]
+  })
+}));
+
+export const canvas = sqliteTable("canvas", {
+  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+  name: text("name")
+});
+
+export const frames = sqliteTable("frames", {
+  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+  name: text("name")
+});
+
+export const subclasses = sqliteTable("subclasses", {
+  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+  name: text("name")
+});
+
+export const effects = sqliteTable("effects", {
+  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+  effect: text("effect")
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -16,7 +16,7 @@ const timestamp = customType<{
 export const sets = sqliteTable("sets", {
     id: text("id").primaryKey().notNull(),
     name: text("name"),
-    abbr: text("abbr"),
+    set_code: text("set_code"),
     series_id: text("series_id").references(() => series.id),
     series_code: text("series_code"),
     release_date: timestamp("release_date"),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,51 +1,54 @@
 import { relations } from "drizzle-orm";
-import {
-  customType,
-  integer,
-  sqliteTable,
-  text,
-} from "drizzle-orm/sqlite-core";
+import { customType, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 const timestamp = customType<{
-  data: Date;
-  driverData: string;
+    data: Date;
+    driverData: string;
 }>({
-  dataType() {
-    return "datetime";
-  },
-  fromDriver(value: string): Date {
-    return new Date(value);
-  },
+    dataType() {
+        return "datetime";
+    },
+    fromDriver(value: string): Date {
+        return new Date(value);
+    },
 });
 
 export const sets = sqliteTable("sets", {
-  id: text("id").primaryKey().notNull(),
-  name: text("name"),
-  abbr: text("abbr"),
-  series_id: text("series_id").references(() => series.id),
-  series_code: text("series_code"),
-  release_date: timestamp("release_date"),
-  image: text("image"),
-  icon: text("icon"),
-  stamp: text("stamp"),
-  logo: text("logo"),
+    id: text("id").primaryKey().notNull(),
+    name: text("name"),
+    abbr: text("abbr"),
+    series_id: text("series_id").references(() => series.id),
+    series_code: text("series_code"),
+    release_date: timestamp("release_date"),
+    image: text("image"),
+    icon: text("icon"),
+    stamp: text("stamp"),
+    logo: text("logo"),
 });
 
 export const setsRelations = relations(sets, ({ one }) => ({
-  series: one(series, {
-    fields: [sets.series_id],
-    references: [series.id],
-  })
+    series: one(series, {
+        fields: [sets.series_id],
+        references: [series.id],
+    }),
 }));
 
 export const series = sqliteTable("series", {
-  id: text("id").primaryKey().notNull(),
-  name: text("name"),
-  image: text("image"),
-  icon: text("icon"),
+    id: text("id").primaryKey().notNull(),
+    name: text("name"),
+    image: text("image"),
+    icon: text("icon"),
 });
 
-export const CardTypes = ["elestral", "spirit", "rune_divine", "rune_staduim", "rune_artifact", "rune_counter", "rune_invoke"] as const;
+export const CardTypes = [
+    "elestral",
+    "spirit",
+    "rune_divine",
+    "rune_staduim",
+    "rune_artifact",
+    "rune_counter",
+    "rune_invoke",
+] as const;
 Object.freeze(CardTypes);
 
 export type CardType = (typeof CardTypes)[number];
@@ -56,101 +59,101 @@ Object.freeze(CardTypes);
 export type CardRarity = (typeof CardRarities)[number];
 
 export const cards = sqliteTable("cards", {
-  id: text("id").primaryKey().notNull(),
-  name: text("name"),
-  base_name: text("base_name"),
-  title: text("title"),
-  alias: text("alias"),
-  set_number: text("set_number"),
-  card_type: text("card_type", { 
-    enum: CardTypes
-  }),
-  rarity: text("rarity", { 
-    enum: CardRarities
-  }),
-  canvas: integer("canvas").references(() => canvas.id),
-  frame_material: integer("frame_material").references(() => frames.id),
-  artist: text("artist"),
-  set_id: text("set_id").references(() => sets.id),
-  render: text("render"),
-  attack: integer("attack"),
-  defense: integer("defense"),
-  serialized_stellar: integer("serialized_stellar"),
-  serialized_population: integer("serialized_population"),
-  is_prize_card: integer("is_prize_card"),
-  prize_rank: integer("prize_rank"),
-  printed_effect: text("printed_effect"),
-  effect_id: text("effect_id"),
-  is_prize_card: integer("is_origin"),
-  subclass_1: integer("subclass_1").references(() => subclasses.id),
-  subclass_2: integer("subclass_2").references(() => subclasses.id),
-  cost_display: text("cost_display"),
-  total_cost: integer("total_cost"),
-  fire_cost: integer("fire_cost"),
-  earth_cost: integer("earth_cost"),
-  thunder_cost: integer("thunder_cost"),
-  water_cost: integer("water_cost"),
-  wind_cost: integer("wind_cost"),
-  frost_cost: integer("frost_cost"),
-  lunar_cost: integer("lunar_cost"),
-  solar_cost: integer("solar_cost"),
-  omni_cost: integer("omni_cost"),
+    id: text("id").primaryKey().notNull(),
+    name: text("name"),
+    base_name: text("base_name"),
+    title: text("title"),
+    alias: text("alias"),
+    set_number: text("set_number"),
+    card_type: text("card_type", {
+        enum: CardTypes,
+    }),
+    rarity: text("rarity", {
+        enum: CardRarities,
+    }),
+    canvas: integer("canvas").references(() => canvas.id),
+    frame_material: integer("frame_material").references(() => frames.id),
+    artist: text("artist"),
+    set_id: text("set_id").references(() => sets.id),
+    render: text("render"),
+    attack: integer("attack"),
+    defense: integer("defense"),
+    serialized_stellar: integer("serialized_stellar"),
+    serialized_population: integer("serialized_population"),
+    is_prize_card: integer("is_prize_card"),
+    prize_rank: integer("prize_rank"),
+    printed_effect: text("printed_effect"),
+    effect_id: text("effect_id"),
+    is_prize_card: integer("is_origin"),
+    subclass_1: integer("subclass_1").references(() => subclasses.id),
+    subclass_2: integer("subclass_2").references(() => subclasses.id),
+    cost_display: text("cost_display"),
+    total_cost: integer("total_cost"),
+    fire_cost: integer("fire_cost"),
+    earth_cost: integer("earth_cost"),
+    thunder_cost: integer("thunder_cost"),
+    water_cost: integer("water_cost"),
+    wind_cost: integer("wind_cost"),
+    frost_cost: integer("frost_cost"),
+    lunar_cost: integer("lunar_cost"),
+    solar_cost: integer("solar_cost"),
+    omni_cost: integer("omni_cost"),
 });
 
 export const cardsRelations = relations(cards, ({ one }) => ({
-  canvas: one(canvas, {
-    fields: [cards.canvas],
-    references: [canvas.id]
-  }),
-  frameMaterial: one(frames, {
-    fields: [cards.frame_material],
-    references: [frames.id]
-  }),
-  set: one(sets, {
-    fields: [cards.set_id],
-    references: [sets.id]
-  }),
-  subclass1: one(subclasses, {
-    fields: [cards.subclass_1],
-    references: [subclasses.id]
-  }),
-  subclass2: one(subclasses, {
-    fields: [cards.subclass_2],
-    references: [subclasses.id]
-  }),
+    canvas: one(canvas, {
+        fields: [cards.canvas],
+        references: [canvas.id],
+    }),
+    frameMaterial: one(frames, {
+        fields: [cards.frame_material],
+        references: [frames.id],
+    }),
+    set: one(sets, {
+        fields: [cards.set_id],
+        references: [sets.id],
+    }),
+    subclass1: one(subclasses, {
+        fields: [cards.subclass_1],
+        references: [subclasses.id],
+    }),
+    subclass2: one(subclasses, {
+        fields: [cards.subclass_2],
+        references: [subclasses.id],
+    }),
 }));
 
 export const variants = sqliteTable("variants", {
-  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
-  variant: text("variant"),
-  card_id: text("card_id").references(() => cards.id),
-  image: text("image"),
-  is_primary: integer("is_primary"),
+    id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+    variant: text("variant"),
+    card_id: text("card_id").references(() => cards.id),
+    image: text("image"),
+    is_primary: integer("is_primary"),
 });
 
 export const variantsRelations = relations(variants, ({ one }) => ({
-  card: one(cards, {
-    fields: [variants.card_id],
-    references: [cards.id]
-  })
+    card: one(cards, {
+        fields: [variants.card_id],
+        references: [cards.id],
+    }),
 }));
 
 export const canvas = sqliteTable("canvas", {
-  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
-  name: text("name"),
+    id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+    name: text("name"),
 });
 
 export const frames = sqliteTable("frames", {
-  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
-  name: text("name"),
+    id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+    name: text("name"),
 });
 
 export const subclasses = sqliteTable("subclasses", {
-  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
-  name: text("name"),
+    id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+    name: text("name"),
 });
 
 export const effects = sqliteTable("effects", {
-  id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
-  effect: text("effect"),
+    id: integer("id").primaryKey({ autoIncrement: true }).notNull(),
+    effect: text("effect"),
 });

--- a/test/db_example.test.ts
+++ b/test/db_example.test.ts
@@ -1,8 +1,7 @@
 import db from "@src/db/connection";
 
-
 describe("db_example", () => {
-  test("db_example", () => {
-    expect(db.query.cards).not.toBeNull();
-  });
+    test("db_example", () => {
+        expect(db.query.cards).not.toBeNull();
+    });
 });

--- a/test/db_example.test.ts
+++ b/test/db_example.test.ts
@@ -1,0 +1,8 @@
+import db from "../src/db/connection";
+
+
+describe("db_example", () => {
+  test("db_example", () => {
+    expect(db.query.cards).not.toBeNull();
+  });
+});

--- a/test/db_example.test.ts
+++ b/test/db_example.test.ts
@@ -1,4 +1,4 @@
-import db from "../src/db/connection";
+import db from "@src/db/connection";
 
 
 describe("db_example", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,10 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false,
 
-    "types": ["@types/bun"]
+    "types": ["@types/bun"],
+    "baseUrl": ".",
+    "paths": {
+      "@src/*": ["src/*"]
+    }
   }
 }


### PR DESCRIPTION
**NOTE:** Run `bun migration:run` to create the initial db as it is not committed to the repo.

- Creates the initial db schema based on discussions.
- Creates an empty db.
- Adds a stub test to confirm the db can be used without error.
- Migrations auto generated by drizzle via `bun migration:create`

This initial code uses enums, which I discovered Drizzle allows for sqlite even though it's not a core feature. This controls drizzle behavior but doesn't enforce it sql side. We'll likely want checks anyway.

This also takes an initial stab at adding drizzle relations, subject to change and refinement as we start working with it.